### PR TITLE
Update MAINTAINER.md to reflect current maintainers

### DIFF
--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -18,24 +18,13 @@ Maintainers are assigned the following scopes in this repository:
 
 | Name             | GitHub ID     | Scope | LFID | Discord ID | Email | Company Affiliation  |
 |----------------- | ------------- | ----- | ---- | ---------- | ----- | -------------------- |
-| Lenin Mehedy     | leninmehedy   |       |      |            |       | Hashgraph            |
-| Jeromy Cannon    | jeromy-cannon |       |      |            |       | Hashgraph            |
-| Nathan Klick     | nathanklick   |       |      |            |       | Hashgraph            |
-| Pavel Borisov    | PavelSBorisov |       |      |            |       | LimeChain            |
-| Roger Barker     | rbarker-dev   |       |      |            |       | Hashgraph            |
-| Andrew Brandt    | andrewb1269hg |       |      |            |       | Hashgraph            |
-| Richard Bair     | rbair23       |       |      |            |       | Hashgraph            |
-| Leemon Baird     | lbaird        |       |      |            |       | Hashgraph            |
-| George Spasov    | Perseverance  |       |      |            |       | Hashgraph            |
-| Hendrik Ebbers   | hendrikebbers |       |      |            |       | Hashgraph            |
-| Alex Popowycz    | popowycz      |       |      |            |       | Hashgraph            |
-| Stoyan Panayotov | stoqnkpL      |       |      |            |       | Hashgraph            |
+|                  |               |       |      |            |       |                      |
 
 ## Emeritus Maintainers
 
-| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
-|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
-|      |           |       |      |            |       |                     |
+| Name             | GitHub ID     | Scope               | LFID | Discord ID | Email | Company Affiliation  |
+|----------------- | ------------- | ------------------- | ---- | ---------- | ----- | -------------------- |
+| George Spasov    | Perseverance  | project-maintainers |      |            |       | Limechain            |
 
 ## The Duties of a Maintainer
 


### PR DESCRIPTION
No need to mention each member since they are already mentioned as a group in the maintainer scope
