### PR TITLE
docs: fix broken project-criteria link in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We will use this repository as a central point for [Github discussions regarding
 
 ### 👉 **Before transfering or adding repos**: Project Criteria for acceptance into hiero-ledger
 
-- [Project criteria guidelines](https://github.com/hiero-ledger/hiero/blob/main/project-criteria.md)
+- [Project criteria guidelines](https://github.com/hiero-ledger/governance/blob/main/rules-and-guidelines/project-criteria.md)
 
 ### 👉 Steps for transfering repos from one GitHub org to another GitHub org
 


### PR DESCRIPTION
**Description**:

The link to `project-criteria.md` in the README was broken because 
the file no longer exists at that path. Updated to point to the 
correct current location in the governance repository.


**Related issue(s)**:

Fixes #116 


